### PR TITLE
feat: better support for Postgres NOTIFY with PgNotificationListener

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/PGConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGConnection.java
@@ -139,6 +139,8 @@ public interface PGConnection {
    */
   void addDataType(String type, Class<? extends PGobject> klass) throws SQLException;
 
+  void addNotificationListener(PGNotificationListener notificationListener) throws SQLException;
+
   /**
    * Set the default statement reuse threshold before enabling server-side prepare. See
    * {@link org.postgresql.PGStatement#setPrepareThreshold(int)} for details.

--- a/pgjdbc/src/main/java/org/postgresql/PGNotificationListener.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGNotificationListener.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2003, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql;
+
+import java.sql.SQLException;
+
+/**
+ * This interface defines the public PostgreSQL extension for Notification Listeners.
+ */
+public abstract class PGNotificationListener {
+  public abstract void handleNotification(PGNotification notification) throws SQLException;
+
+  public void handleSQLException(SQLException e) {
+    // NOOP by default, this method exists to encourage overriding on listener creation.
+  }
+
+  public void handleInterruptedException(InterruptedException e) {
+    // NOOP by default, this method exists to encourage overriding on listener creation.
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/NotifyTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/NotifyTest.java
@@ -8,9 +8,11 @@ package org.postgresql.test.jdbc2;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
 
 import org.postgresql.PGConnection;
 import org.postgresql.PGNotification;
+import org.postgresql.PGNotificationListener;
 import org.postgresql.core.ServerVersion;
 import org.postgresql.test.TestUtil;
 
@@ -22,6 +24,7 @@ import org.junit.Test;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.concurrent.TimeUnit;
 
 public class NotifyTest {
   private Connection conn;
@@ -95,6 +98,53 @@ public class NotifyTest {
     assertEquals(1, notifications.length);
     assertEquals("mynotification", notifications[0].getName());
     assertEquals("", notifications[0].getParameter());
+
+    stmt.close();
+  }
+
+  @Test(timeout = 60000)
+  public void testNotificationListener() throws Exception {
+    Statement stmt = conn.createStatement();
+    stmt.execute("LISTEN notificationListener");
+
+    final int[] notificationsReceived = {0};
+    final int[] notificationExceptions = {0};
+
+    // Add a notification listener to the connection
+    conn.unwrap(PGConnection.class).addNotificationListener(new PGNotificationListener() {
+      @Override
+      public void handleNotification(PGNotification notification) throws SQLException {
+        // Make the handleNotification method throw an exception once, to ensure handleSQLException works as expected
+        if (notification.getParameter().equals("7")) {
+          throw new SQLException();
+        }
+        notificationsReceived[0] += 1;
+      }
+
+      @Override
+      public void handleSQLException(SQLException e) {
+        notificationExceptions[0] += 1;
+      }
+    });
+
+    // Spin up a thread that sends a NOTIFY command ten times in a second
+    new Thread( new Runnable() {
+      public void run() {
+        try {
+          for (int x = 0; x <= 10; x++) {
+            TimeUnit.MILLISECONDS.sleep(100);
+            connectAndNotify("notificationListener", String.valueOf(x));
+          }
+        } catch (InterruptedException ie) {
+          fail("Thread generating notifications was interrupted");
+        }
+      }
+    }).start();
+
+    // Wait 2 seconds to get all of the notifications
+    TimeUnit.SECONDS.sleep(3);
+    Assert.assertEquals("There should be ten notifications received without error", 10, notificationsReceived[0]);
+    Assert.assertEquals("There should have been one exception caught in the listener", 1, notificationExceptions[0]);
 
     stmt.close();
   }
@@ -238,11 +288,16 @@ public class NotifyTest {
   }
 
   private static void connectAndNotify(String channel) {
+    connectAndNotify(channel, null);
+  }
+
+  private static void connectAndNotify(String channel, String payload) {
     Connection conn2 = null;
+    String notifyQuery = "NOTIFY " + channel + (payload == null ? "" : ", '" + payload + "'");
     try {
       conn2 = TestUtil.openDB();
       Statement stmt2 = conn2.createStatement();
-      stmt2.executeUpdate("NOTIFY " + channel);
+      stmt2.executeUpdate(notifyQuery);
       stmt2.close();
     } catch (Exception e) {
       throw new RuntimeException("Couldn't notify '" + channel + "'.",e);


### PR DESCRIPTION
add ability to pass a notification listener object/function to a PgConnection object; this allows for asynchronous handling of the receipt of NOTIFY messages via a LISTEN command rather than always calling PgConnection.getNotifications

### All Submissions:

* [✓] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [✓] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### New Feature Submissions:

1. [✓] Does your submission pass tests?
2. [✓] Does mvn checkstyle:check pass ?
3. [✓] Have you added your new test classes to an existing test suite in alphabetical order?

### Changes to Existing Features:

* [✓] Have you added an explanation of what your changes do and why you'd like us to include them?
* [✓] Have you written new tests for your core changes, as applicable?
* [✓] Have you successfully run tests with your changes locally?
